### PR TITLE
docs: Add troubleshooting and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,12 @@
+# Troubleshooting Guide
+
+## Common Issues
+
+### 1. Virtual Environment Errors
+If you get a "Command not found" error when running `python` or `pip`, ensure your virtual environment is activated:
+- Windows: `venv\Scripts\activate`
+- macOS/Linux: `source venv/bin/activate`
+
+### 2. Dependency Installation Fails
+Ensure you have the correct Python version installed and that your `pip` is up to date:
+`python -m pip install --upgrade pip`


### PR DESCRIPTION
This PR adds a `docs/TROUBLESHOOTING.md` guide for common local setup errors and configures Dependabot for dependency updates.

Resolves #94, Resolves #95